### PR TITLE
Try to re-enable tests on nightly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         version:
           - '1'
-          #- 'nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
         include:


### PR DESCRIPTION
I ran into what looks like [this issue](https://github.com/JuliaLang/julia/issues/53572), when [compiling `UnPack` took about 5 hours](https://github.com/moble/SphericalFunctions.jl/actions/runs/8236808128/job/22530185260?pr=35#step:6:345).  The issue is reportedly fixed now, so I'll try again.  (Might have to try again tomorrow, or even the next day, because the nightly probably hasn't been updated yet.)